### PR TITLE
Support Jekyll 2 & 3

### DIFF
--- a/lib/octopress-pullquote-tag/utils.rb
+++ b/lib/octopress-pullquote-tag/utils.rb
@@ -10,9 +10,19 @@ module Octopress
           txext = site.config['textile_ext']
 
           if mdext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Markdown).convert(content)
+            markdown_converter = if site.respond_to?(:find_converter_instance)
+              site.find_converter_instance(Jekyll::Converters::Markdown)
+            else
+              site.getConverterImpl(Jekyll::Converters::Markdown)
+            end
+            markdown_converter.convert(content)
           elsif txext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Textile).convert(content)
+            textile_converter = if site.respond_to?(:find_converter_instance)
+              site.find_converter_instance(Jekyll::Converters::Textile)
+            else
+              site.getConverterImpl(Jekyll::Converters::Textile)
+            end
+            textile_converter.convert(content)
           else
             "<p>" + content.strip.gsub(/\n\n/, "<p>\n\n</p>") + "</p>"
           end


### PR DESCRIPTION
Jekyll 3 renamed site.getConverterImpl to site.find_converter_instance.
Check whether the new API is available and use that, fall back to the
old version otherwise. This keeps compatibility with both versions.

Based on operasoftware/devopera#269 and octopress/quote-tag#6